### PR TITLE
Update opt_2dhisto.cu

### DIFF
--- a/lab3/opt_2dhisto.cu
+++ b/lab3/opt_2dhisto.cu
@@ -221,6 +221,8 @@ extern "C" void opt_2dhisto(int size)
   test_xform xform;
   test_sumfun sum;
   callHistogramKernel<histogram_atomic_inc, 1>(d_Data, xform, sum, 0, size, 0U, d_Histogram, HISTO_HEIGHT * HISTO_WIDTH, true);
+  cudaDeviceSynchronize();
+    
 }
 
 extern "C" void opt_free()


### PR DESCRIPTION
I was having trouble copying back the array from device; adding this synchronization primitive line at the end of the kernel calling function helped.
